### PR TITLE
Fix Sprite Jitter

### DIFF
--- a/TheDialgaTeam.FossilFighters.Assets/Motion/MotionUtility.cs
+++ b/TheDialgaTeam.FossilFighters.Assets/Motion/MotionUtility.cs
@@ -141,8 +141,8 @@ public static class MotionUtility
                 {
                     for (var x = 0; x < gridSize; x += 2)
                     {
-                        image[x + gridX * gridSize, y + gridY * gridSize] = colorPalette.Colors[bitmap.ColorPaletteIndexes[bitmapIndex] >> 4];
-                        image[x + 1 + gridX * gridSize, y + gridY * gridSize] = colorPalette.Colors[bitmap.ColorPaletteIndexes[bitmapIndex] & 0xF];
+                        image[x + gridX * gridSize, y + gridY * gridSize] = colorPalette.Colors[bitmap.ColorPaletteIndexes[bitmapIndex] & 0xF];
+                        image[x + 1 + gridX * gridSize, y + gridY * gridSize] = colorPalette.Colors[bitmap.ColorPaletteIndexes[bitmapIndex] >> 4];
 
                         bitmapIndex++;
                     }


### PR DESCRIPTION
This fixes the bug that makes some sprites look all 'jittery' like so:
![image](https://github.com/jianmingyong/Fossil-Fighters-Tool/assets/20342854/07585f39-b922-48d7-a1a7-64a14febff59)

It was caused by writing each half of the byte in a 16-color palette index in the wrong order.